### PR TITLE
MTO-1562 fix admin display bug on missing permissions

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -353,7 +353,7 @@ class Menu(object):
         }
 
     def get_native_model_url(self, model):
-        return model.get('admin_url', model.get('add_url', ''))
+        return model.get('admin_url') or model.get('add_url') or ''
 
     def process_model(self, model, app_name):
         if 'model' in model:


### PR DESCRIPTION
Sentry issue: https://prezzee.sentry.io/issues/6352881626/

This PR addresses a bug that occurs when a user is missing view permissions and the value is `None` instead of missing from the dict.

```
{
  add_url: "/admin/business/campaign/add/",
  admin_url: None,
  model: <class 'business.models.Campaign'>,
  name: "Campaigns",
  object_name: "Campaign",

  perms: {
    add: True,
    change: False,
    delete: False,
    view: False
  }
}
```